### PR TITLE
Removes ContainerLogs from integration suite

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -64,14 +64,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/paketo-buildpacks/occam v0.0.14 h1:8kvKwOjGAeUxTvS48aP6KOzqpPfBp21U9nrymOoBSME=
-github.com/paketo-buildpacks/occam v0.0.14/go.mod h1:YzM19WUBeTUYldLWujLR1BE0BfyFiECvluds0ZhbORo=
 github.com/paketo-buildpacks/occam v0.0.15 h1:kAmAzqOTmff4rX+LA1LecOed1jM80y9J5wuky/1tkt0=
 github.com/paketo-buildpacks/occam v0.0.15/go.mod h1:L95oaK761JmBMsst59F83J6Lfx7XW+HkOWh3OGo6btc=
 github.com/paketo-buildpacks/packit v0.0.14 h1:ySq6WC/WKsOmUdsg9Uh1ggpDkyV0opJuJTus5DYv+lg=
 github.com/paketo-buildpacks/packit v0.0.14/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
-github.com/paketo-buildpacks/packit v0.0.15 h1:BYcZAyHcKF+n9DKroAiYC1CgbCHIshcerxeMYq5rq4A=
-github.com/paketo-buildpacks/packit v0.0.15/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
 github.com/paketo-buildpacks/packit v0.0.16 h1:UMo3r4uAA/tj9qhQgPd6Kg7Lt7jc5YIUHoyNFzwqV+0=
 github.com/paketo-buildpacks/packit v0.0.16/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -37,13 +36,4 @@ func TestIntegration(t *testing.T) {
 	suite("NPM", testNPM)
 	suite("Yarn", testYarn)
 	suite.Run(t)
-}
-
-func ContainerLogs(id string) func() string {
-	docker := occam.NewDocker()
-
-	return func() string {
-		logs, _ := docker.Container.Logs.Execute(id)
-		return logs.String()
-	}
 }

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -63,7 +63,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			container, err = docker.Container.Run.Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container, "5s").Should(BeAvailable(), ContainerLogs(container.ID))
+			Eventually(container, "5s").Should(BeAvailable())
 
 			response, err := http.Get(fmt.Sprintf("http://localhost:%s/env", container.HostPort()))
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The `BeAvailable` method will already fetch logs if the assertion fails