### PR TITLE
Removes Tini from yarn order grouping

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -24,12 +24,8 @@ api = "0.2"
     version = "0.2.0"
 
   [[order.group]]
-    id = "paketo-buildpacks/tini"
-    version = "0.0.2"
-
-  [[order.group]]
     id = "paketo-buildpacks/yarn-start"
-    version = "0.0.1"
+    version = "0.0.2"
 
 [[order]]
 

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -59,8 +59,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Tini Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Yarn-Start Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 
 			container, err = docker.Container.Run.Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())

--- a/package.toml
+++ b/package.toml
@@ -17,7 +17,4 @@
   image = "gcr.io/paketo-buildpacks/yarn:0.0.2"
 
 [[dependencies]]
-  image = "gcr.io/paketo-buildpacks/tini:0.0.2"
-
-[[dependencies]]
-  image = "gcr.io/paketo-buildpacks/yarn-start:0.0.1"
+  image = "gcr.io/paketo-buildpacks/yarn-start:0.0.2"


### PR DESCRIPTION
Removes tini from yarn order grouping and updates yarn-start version to 0.0.2

Signed-off-by: Timothy Hitchener <thitchener@pivotal.io>