### PR TITLE
Adds environment-variables buildpack to order groupings

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -31,6 +31,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version="3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -50,6 +55,11 @@ api = "0.2"
     optional = true
     version = "4.0.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version="3.0.0"
+
 [[order]]
 
   [[order.group]]
@@ -64,3 +74,8 @@ api = "0.2"
     id = "paketo-buildpacks/procfile"
     optional = true
     version = "4.0.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version="3.0.0"

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -67,6 +67,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Install Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8080"}).
@@ -91,17 +92,18 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 
 		})
 
-		context("when there is a Procfile", func() {
+		context("when using optional utility buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: node server.js"), 0644)).To(Succeed())
 			})
 
-			it("builds a working OCI image for a simple app and uses the Procfile start command", func() {
+			it("builds a working OCI image for a simple app and uses the Procfile start command and other utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(nodeBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{"BPE_SOME_VARIABLE": "some-value"}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -110,6 +112,9 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
+				Expect(image.Buildpacks[4].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -67,6 +67,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8080"}).
@@ -82,17 +83,17 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 
-		context("when there is a Procfile", func() {
+		context("when using optional utility buildpacks", func() {
 			it.Before(func() {
 				Expect(ioutil.WriteFile(filepath.Join(source, "Procfile"), []byte("web: node server.js"), 0644)).To(Succeed())
 			})
-
-			it("should build a working OCI image for a simple app", func() {
+			it("should build a working OCI image and run the app with the start command from the Procfile and other utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
 					WithBuildpacks(nodeBuildpack).
 					WithPullPolicy("never").
+					WithEnv(map[string]string{"BPE_SOME_VARIABLE": "some-value"}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -102,6 +103,9 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
+				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
+
+				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
@@ -114,7 +118,12 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 
 				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
 				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
 				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				content, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("Hello, World!"))
 			})
 		})
 	})

--- a/package.toml
+++ b/package.toml
@@ -25,3 +25,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/procfile:4.0.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/environment-variables:3.0.0"


### PR DESCRIPTION
Signed-off-by: Timothy Hitchener <thitchener@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds `environment-variables` buildpack to Node.js buildpack order groupings
## Use Cases
<!-- An explanation of the use cases your change enables -->
Allows users to embed environment variables into their app images.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
