### PR TITLE
add node run script to order groupings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ This buildpack also includes the following utility buildpacks:
 - [Environment Variables CNB](https://github.com/paketo-buildpacks/environment-variables)
 - [Image Labels CNB](https://github.com/paketo-buildpacks/image-labels)
 - [CA Certificates CNB](https://github.com/paketo-buildpacks/ca-certificates)
+- [Node Run Script CNB](https://github.com/paketo-buildpacks/node-run-script)
 
 Check out the [Paketo Node.js docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for more information.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,6 +28,11 @@ api = "0.4"
     version = "0.4.0"
 
   [[order.group]]
+    id = "paketo-buildpacks/node-run-script"
+    optional = true
+    version = "0.1.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/yarn-start"
     version = "0.2.0"
 
@@ -60,6 +65,11 @@ api = "0.4"
   [[order.group]]
     id = "paketo-buildpacks/npm-install"
     version = "0.4.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-run-script"
+    optional = true
+    version = "0.1.0"
 
   [[order.group]]
     id = "paketo-buildpacks/npm-start"

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -105,8 +105,9 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(nodeBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":   "some-value",
+						"BP_IMAGE_LABELS":     "some-label=some-value",
+						"BP_NODE_RUN_SCRIPTS": "some-script",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
@@ -118,8 +119,9 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/integration/testdata/npm/package.json
+++ b/integration/testdata/npm/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "some app",
   "scripts": {
+    "some-script": "echo \"npm scripts running!\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/integration/testdata/yarn/package.json
+++ b/integration/testdata/yarn/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "some app",
   "scripts": {
+    "some-script": "echo \"yarn scripts running!\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -97,8 +97,9 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 					WithBuildpacks(nodeBuildpack).
 					WithPullPolicy("never").
 					WithEnv(map[string]string{
-						"BPE_SOME_VARIABLE": "some-value",
-						"BP_IMAGE_LABELS":   "some-label=some-value",
+						"BPE_SOME_VARIABLE":   "some-value",
+						"BP_IMAGE_LABELS":     "some-label=some-value",
+						"BP_NODE_RUN_SCRIPTS": "some-script",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
@@ -111,8 +112,9 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/package.toml
+++ b/package.toml
@@ -34,3 +34,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/ca-certificates:2.3.2"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/node-run-script:0.1.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
with the finalized PR and [release](https://github.com/paketo-buildpacks/node-run-script/releases/tag/v0.1.0) cut of the node run script buildpack, the next step is to add that buildpack to the order groupings of the Node.js family CNB. This PR adds the buildpack to the order groupings.
## Use Cases
<!-- An explanation of the use cases your change enables -->
This buildpack adds node run script to the order groupings as an optional buildpack, allowing for it to be used during detect phases of the node JS family CNB, which would let users easily run scripts in their `package.jsons` in the build phase.
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
