### PR TITLE
Add Node Module BOM CNB to order groupings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ This buildpack also includes the following utility buildpacks:
 - [Image Labels CNB](https://github.com/paketo-buildpacks/image-labels)
 - [CA Certificates CNB](https://github.com/paketo-buildpacks/ca-certificates)
 - [Node Run Script CNB](https://github.com/paketo-buildpacks/node-run-script)
+- [Node Module Bill of Materials CNB](https://github.com/paketo-buildpacks/node-module-bom)
 
 Check out the [Paketo Node.js docs](https://paketo.io/docs/buildpacks/language-family-buildpacks/nodejs/) for more information.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,6 +28,11 @@ api = "0.4"
     version = "0.4.0"
 
   [[order.group]]
+    id = "paketo-buildpacks/node-module-bom"
+    optional = true
+    version = "0.1.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/node-run-script"
     optional = true
     version = "0.1.0"
@@ -67,6 +72,11 @@ api = "0.4"
     version = "0.4.0"
 
   [[order.group]]
+    id = "paketo-buildpacks/node-module-bom"
+    optional = true
+    version = "0.1.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/node-run-script"
     optional = true
     version = "0.1.0"
@@ -100,6 +110,11 @@ api = "0.4"
   [[order.group]]
     id = "paketo-buildpacks/node-engine"
     version = "0.6.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-module-bom"
+    optional = true
+    version = "0.1.0"
 
   [[order.group]]
     id = "paketo-buildpacks/node-start"

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -67,10 +67,13 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Install Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
+
+			Expect(image.Buildpacks[3].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8080"}).
@@ -114,6 +117,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Install Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
@@ -121,8 +125,9 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
+				Expect(image.Buildpacks[3].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
@@ -187,7 +192,9 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("CA Certificates Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Install Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
+				Expect(image.Buildpacks[3].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				// NOTE: NODE_OPTIONS="--use-openssl-ca" is NOT required since the node binary is compiled with `--openssl-use-def-ca-store`
 				container, err = docker.Container.Run.

--- a/integration/testdata/vendored/README.md
+++ b/integration/testdata/vendored/README.md
@@ -1,0 +1,1 @@
+This file here to suppress "npm WARN package.json node_web_app@0.0.0 No README data"

--- a/integration/testdata/vendored/node_modules/leftpad/CHANGELOG.md
+++ b/integration/testdata/vendored/node_modules/leftpad/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="0.0.1"></a>
+## 0.0.1 (2017-05-03)

--- a/integration/testdata/vendored/node_modules/leftpad/README.md
+++ b/integration/testdata/vendored/node_modules/leftpad/README.md
@@ -1,0 +1,13 @@
+## leftpad
+
+[![CircleCI](https://circleci.com/gh/tmcw/leftpad/tree/master.svg?style=shield)](https://circleci.com/gh/tmcw/leftpad/tree/master)
+
+Like the [pad module](https://github.com/wdavidw/node-pad), except I'll remember
+the argument order.
+
+```js
+var leftpad = require('leftpad');
+
+leftpad(5, 10);
+'0000000005'
+```

--- a/integration/testdata/vendored/node_modules/leftpad/index.js
+++ b/integration/testdata/vendored/node_modules/leftpad/index.js
@@ -1,0 +1,7 @@
+module.exports = function(str, width, char) {
+  char = char || "0";
+  str = str.toString();
+  while (str.length < width)
+    str = char + str;
+  return str;
+};

--- a/integration/testdata/vendored/node_modules/leftpad/license
+++ b/integration/testdata/vendored/node_modules/leftpad/license
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Tom MacWright
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/integration/testdata/vendored/node_modules/leftpad/package.json
+++ b/integration/testdata/vendored/node_modules/leftpad/package.json
@@ -1,0 +1,59 @@
+{
+  "_from": "leftpad@~0.0.1",
+  "_id": "leftpad@0.0.1",
+  "_inBundle": false,
+  "_integrity": "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=",
+  "_location": "/leftpad",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "leftpad@~0.0.1",
+    "name": "leftpad",
+    "escapedName": "leftpad",
+    "rawSpec": "~0.0.1",
+    "saveSpec": null,
+    "fetchSpec": "~0.0.1"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz",
+  "_shasum": "86b1a4de4face180ac545a83f1503523d8fed115",
+  "_spec": "leftpad@~0.0.1",
+  "_where": "/Users/swigmore/workspace/paketo-buildpacks/nodejs/integration/testdata/vendored",
+  "author": {
+    "name": "Tom MacWright",
+    "email": "tom@macwright.org"
+  },
+  "bugs": {
+    "url": "https://github.com/tmcw/leftpad/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": "Use the built-in String.padStart function instead",
+  "description": "left pad numbers",
+  "devDependencies": {
+    "jsverify": "^0.8.2"
+  },
+  "files": [
+    "index.js"
+  ],
+  "homepage": "https://github.com/tmcw/leftpad#readme",
+  "keywords": [
+    "pad",
+    "numbers",
+    "formatting",
+    "format"
+  ],
+  "license": "BSD-3-Clause",
+  "main": "index.js",
+  "name": "leftpad",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tmcw/leftpad.git"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "version": "0.0.1"
+}

--- a/integration/testdata/vendored/server.js
+++ b/integration/testdata/vendored/server.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const leftpad = require('leftpad');
+
+const port = process.env.PORT || 8080;
+
+const requestHandler = (request, response) => {
+    response.end("hello world")
+}
+
+const server = http.createServer(requestHandler)
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.log('something bad happened', err);
+  }
+    console.log(`server is listening on ${port}`)
+});

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -67,10 +67,13 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
+
+			Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8080"}).
@@ -107,6 +110,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
@@ -114,8 +118,9 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
+				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
@@ -180,7 +185,10 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
+
+				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				// NOTE: NODE_OPTIONS="--use-openssl-ca" is NOT required since the node binary is compiled with `--openssl-use-def-ca-store`
 				container, err = docker.Container.Run.

--- a/package.toml
+++ b/package.toml
@@ -37,3 +37,6 @@
 
 [[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/node-run-script:0.1.0"
+
+[[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/node-module-bom:0.1.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #438 

## Use Cases
<!-- An explanation of the use cases your change enables -->

Allows users to get Bill of Materials entries for node modules when they run `pack inspect-image <app-image> --bom`

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
