### PR TITLE
[BLOCKED] remove Node Module BOM BP from Yarn group

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,11 +33,6 @@ api = "0.6"
     version = "0.6.0"
 
   [[order.group]]
-    id = "paketo-buildpacks/node-module-bom"
-    optional = true
-    version = "0.2.0"
-
-  [[order.group]]
     id = "paketo-buildpacks/node-run-script"
     optional = true
     version = "0.3.0"

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -67,13 +67,10 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
-			Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
-
-			Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{"PORT": "8080"}).
@@ -112,7 +109,6 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("web: node server.js")))
@@ -120,10 +116,9 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[9].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[9].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
-				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				container, err = docker.Container.Run.
 					WithEnv(map[string]string{"PORT": "8080"}).
@@ -179,10 +174,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Install Buildpack")))
-				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
-
-				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 
 				// NOTE: NODE_OPTIONS="--use-openssl-ca" is NOT required since the node binary is compiled with `--openssl-use-def-ca-store`
 				container, err = docker.Container.Run.


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

As a part of #496, this PR removes the Node Module BOM Buildpack from the Yarn order grouping. BOM creation will be delegated to the Yarn Install buildpack instead in this order group.
This PR will be unblocked by https://github.com/paketo-buildpacks/yarn-install/pull/285 being merged and released.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
