### PR TITLE
Add (optional) datadog to all order groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bin
 /build
+.idea/

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -62,6 +62,11 @@ api = "0.6"
     version = "5.1.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/datadog"
+    optional = true
+    version = "1.4.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.1.1"
@@ -117,6 +122,11 @@ api = "0.6"
     version = "5.1.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/datadog"
+    optional = true
+    version = "1.4.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.1.1"
@@ -155,6 +165,11 @@ api = "0.6"
     id = "paketo-buildpacks/procfile"
     optional = true
     version = "5.1.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/datadog"
+    optional = true
+    version = "1.4.0"
 
   [[order.group]]
     id = "paketo-buildpacks/environment-variables"

--- a/integration/node_start_test.go
+++ b/integration/node_start_test.go
@@ -67,6 +67,7 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -101,6 +102,7 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 						"BPE_SOME_VARIABLE":      "some-value",
 						"BP_IMAGE_LABELS":        "some-label=some-value",
 						"BP_LIVE_RELOAD_ENABLED": "true",
+						"BP_DATADOG_ENABLED":     "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
@@ -108,12 +110,13 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Engine Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Datadog Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[5].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.
@@ -162,6 +165,7 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -71,6 +71,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("NPM Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -137,6 +138,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -203,6 +205,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -250,6 +253,7 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 						"BP_IMAGE_LABELS":        "some-label=some-value",
 						"BP_NODE_RUN_SCRIPTS":    "some-script",
 						"BP_LIVE_RELOAD_ENABLED": "true",
+						"BP_DATADOG_ENABLED":     "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
@@ -261,12 +265,13 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Module Bill of Materials Generator Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("NPM Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Datadog Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[9].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[9].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[10].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[10].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 				Expect(image.Buildpacks[4].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -71,6 +71,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -132,6 +133,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -192,6 +194,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Procfile Buildpack")))
+			Expect(logs).NotTo(ContainLines(ContainSubstring("Datadog Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Image Labels Buildpack")))
 
@@ -232,6 +235,7 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 						"BP_IMAGE_LABELS":        "some-label=some-value",
 						"BP_NODE_RUN_SCRIPTS":    "some-script",
 						"BP_LIVE_RELOAD_ENABLED": "true",
+						"BP_DATADOG_ENABLED":     "true",
 					}).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred())
@@ -244,12 +248,13 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Node Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Yarn Start Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Procfile Buildpack")))
+				Expect(logs).To(ContainLines(ContainSubstring("Datadog Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
 				Expect(logs).To(ContainLines(ContainSubstring("Node Run Script")))
 
-				Expect(image.Buildpacks[10].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[10].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[11].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[11].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 				Expect(image.Buildpacks[5].Key).To(Equal("paketo-buildpacks/node-module-bom"))
 

--- a/package.toml
+++ b/package.toml
@@ -43,3 +43,6 @@
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/watchexec@2.4.0"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/datadog@1.4.0"


### PR DESCRIPTION
Add (optional) [datadog](https://github.com/paketo-buildpacks/datadog) buildpack to all order groups.

Resolves #559

## Use Cases
Allows developers to instrument their `nodejs` apps with datadog. Always optional, requires `BP_DATADOG_ENABLED` to be truthy to participate in the build. 

## NOTES
- The only thing checked in the integration tests is the logs. It's not immediately clear to be how we might directly verify that the datadog buildpack has done its work, although there are some options.
  - Verify that the main module has [`require('dd-trace').init();`](https://github.com/paketo-buildpacks/datadog/blob/5839fdad5182a111068345a23efef98ebe2c9c52/datadog/nodejs_agent.go#L81) at the top
  - Verify that the layer contributed by `datadog` [modifies the `NODE_PATH`](https://github.com/paketo-buildpacks/datadog/blob/5839fdad5182a111068345a23efef98ebe2c9c52/datadog/nodejs_agent.go#L59)
- The datadog buildpack [modifies the application source code](https://github.com/paketo-buildpacks/datadog/blob/5839fdad5182a111068345a23efef98ebe2c9c52/datadog/nodejs_agent.go#L81). How comfortable are we with this? I don't believe it would impact layer reuse (since the source files remain in the application directory). I think alternatively we could use `NODE_OPTIONS` to add a `--require` flag to the `node` start command as shown in the [`datadog docs`](https://docs.datadoghq.com/tracing/setup_overview/setup/nodejs/?tab=containers#adding-the-tracer-via-command-line-arguments), but that's an implementation decision inside the datadog buildpack and does not impact this PR.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have ~~added~~ **modified** an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
