### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node.js Paketo Buildpack
+# Paketo Buildpack for Node.js
 
 ## `gcr.io/paketo-buildpacks/nodejs`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.6"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/nodejs"
   id = "paketo-buildpacks/nodejs"
-  name = "Paketo Node.js Buildpack"
+  name = "Paketo Buildpack for Node.js"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Node.js Buildpack' to 'Paketo Buildpack for Node.js'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
