### PR TITLE
Upgrade yarn buildpack to v1.3.10

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -30,7 +30,7 @@ api = "0.7"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn"
-    version = "1.3.5"
+    version = "1.3.10"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn-install"

--- a/package.toml
+++ b/package.toml
@@ -18,7 +18,7 @@
   uri = "urn:cnb:registry:paketo-buildpacks/yarn-install@2.0.1"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/yarn@1.3.5"
+  uri = "urn:cnb:registry:paketo-buildpacks/yarn@1.3.10"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/yarn-start@2.0.1"


### PR DESCRIPTION
Fixes https://github.com/paketo-buildpacks/yarn/issues/616 by upgrading the yarn buildpack to v1.3.10 as https://github.com/paketo-buildpacks/yarn/pull/617