### PR TITLE
Allow npm-install and yarn-install to request python to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage examples can be found in the
 - [Paketo Base Builder](https://github.com/paketo-buildpacks/base-builder) (for apps which do not leverage common C libraries)
 
 This buildpack also includes the following utility buildpacks:
+- [cPython CNB](https://github.com/paketo-buildpacks/cpython)
 - [Procfile CNB](https://github.com/paketo-buildpacks/procfile)
 - [Environment Variables CNB](https://github.com/paketo-buildpacks/environment-variables)
 - [Image Labels CNB](https://github.com/paketo-buildpacks/image-labels)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -29,6 +29,11 @@ api = "0.7"
     version = "4.1.11"
 
   [[order.group]]
+    id = "paketo-buildpacks/cpython"
+    optional = true
+    version = "1.13.7"
+
+  [[order.group]]
     id = "paketo-buildpacks/yarn"
     version = "1.3.15"
 
@@ -81,6 +86,11 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/node-engine"
     version = "4.1.11"
+
+  [[order.group]]
+    id = "paketo-buildpacks/cpython"
+    optional = true
+    version = "1.13.7"
 
   [[order.group]]
     id = "paketo-buildpacks/npm-install"

--- a/integration.json
+++ b/integration.json
@@ -1,8 +1,6 @@
 {
   "ubi-nodejs-extension": "github.com/paketo-community/ubi-nodejs-extension",
   "builders": [
-    "paketocommunity/builder-ubi-buildpackless-base",
-    "paketobuildpacks/builder:buildpackless-base",
     "paketobuildpacks/builder-jammy-buildpackless-base"
   ]
 }

--- a/integration/testdata/node-gyp/index.js
+++ b/integration/testdata/node-gyp/index.js
@@ -1,0 +1,13 @@
+const express = require('express')
+const app = express()
+const port = process.env.PORT || 8080
+
+const features = require('cpu-features')();
+
+app.get('/', (req, res) => {
+    res.send(features)
+})
+
+app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`)
+})

--- a/integration/testdata/node-gyp/package.json
+++ b/integration/testdata/node-gyp/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "simple_app",
+    "version": "0.0.0",
+    "description": "some app",
+      "main": "index.js",
+    "scripts": {
+      "start": "node index.js",
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+      "cpu-features": "^0.0.4",
+      "express": "^4.18.2"
+    },
+    "devDependencies": {
+      "node-gyp": "^9.3.1"
+    }
+  }

--- a/package.toml
+++ b/package.toml
@@ -24,6 +24,9 @@
   uri = "urn:cnb:registry:paketo-buildpacks/yarn-start@2.0.10"
 
 [[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/cpython@1.13.7"
+
+[[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/procfile@5.9.2"
 
 [[dependencies]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

see https://github.com/paketo-buildpacks/nodejs/issues/691

prerequisite: https://github.com/paketo-buildpacks/npm-install/pull/753 - needed to actually request `cpython` when needed


## Summary
Allow `npm-install` and `yarn-install` to request `cpython` if needed during build (dependency to `node-gyp`).

## Use Cases
You don't have to use the full stack as soon as your app has a dependency to `node-gyp`

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
