### PR TITLE
feat: remove DataDog support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -57,11 +57,6 @@ api = "0.7"
     version = "5.9.0"
 
   [[order.group]]
-    id = "paketo-buildpacks/datadog"
-    optional = true
-    version = "3.6.0"
-
-  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.7.0"
@@ -112,11 +107,6 @@ api = "0.7"
     version = "5.9.0"
 
   [[order.group]]
-    id = "paketo-buildpacks/datadog"
-    optional = true
-    version = "3.6.0"
-
-  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.7.0"
@@ -150,11 +140,6 @@ api = "0.7"
     id = "paketo-buildpacks/procfile"
     optional = true
     version = "5.9.0"
-
-  [[order.group]]
-    id = "paketo-buildpacks/datadog"
-    optional = true
-    version = "3.6.0"
 
   [[order.group]]
     id = "paketo-buildpacks/environment-variables"

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.5.2/go.mod h1:nQCiF4Tvrg5Ieu8qPhYMvzPGMu5I7fANZkrSsJjl5mg=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/ForestEckhardt/freezer v0.1.0 h1:1Av1G+uJTmhhJGuV8MkVLdiEH8ljuiBaV+Cgy30QbRE=
 github.com/ForestEckhardt/freezer v0.1.0/go.mod h1:fQApI/B3u/Pu6DD4rxmzBJQUBDc9EDu7ieqM6l4JvZA=

--- a/integration/node_start_test.go
+++ b/integration/node_start_test.go
@@ -74,7 +74,6 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Engine")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -118,7 +117,6 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Engine")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Datadog")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
@@ -175,7 +173,6 @@ func testNodeStart(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Engine")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -76,7 +76,6 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for NPM Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -141,7 +140,6 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -206,7 +204,6 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -264,7 +261,6 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Install")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Start")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Datadog")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -77,7 +77,6 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Yarn Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -137,7 +136,6 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Yarn Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -196,7 +194,6 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 			Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Yarn Start")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
-			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Datadog")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 			Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 
@@ -248,7 +245,6 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Start")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Yarn Start")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
-				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Datadog")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))

--- a/package.toml
+++ b/package.toml
@@ -40,6 +40,3 @@
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/watchexec@3.2.1"
-
-[[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/datadog@3.6.0"


### PR DESCRIPTION
Refs: https://github.com/paketo-buildpacks/nodejs/issues/906

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Remove the data dog buildpack from the Node.js metabuildpack. Recent updates
do not pass existing tests and some work would be needed to resolve. Talking
to people I know on the the DataDog team they suggested that we remove as it
uses a deprecated approach of injecting the agent for Node.js. There have
been no concerns/objections in - https://github.com/paketo-buildpacks/nodejs/issues/906 which I opened a while back with the suggestion that we remove it.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
