### PR TITLE
Update package.toml to support multi-arch

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,8 +1,8 @@
 {
-  "ubi-nodejs-extension": "github.com/paketo-buildpacks/ubi-nodejs-extension",
+  "ubi-nodejs-extension": "index.docker.io/paketobuildpacks/ubi-nodejs-extension",
   "builders": [
-    "paketobuildpacks/ubi-9-builder-buildpackless",
-    "paketobuildpacks/builder-ubi8-buildpackless-base",
-    "paketobuildpacks/builder-jammy-buildpackless-base"
+    "index.docker.io/paketobuildpacks/ubi-9-builder-buildpackless",
+    "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base",
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base"
   ]
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,12 +46,8 @@ func TestIntegration(t *testing.T) {
 	Expect(json.NewDecoder(file).Decode(&settings.Config)).To(Succeed())
 	Expect(file.Close()).To(Succeed())
 
-	buildpackStore := occam.NewBuildpackStore()
-
-	if builder.BuilderName == "paketobuildpacks/builder-ubi8-buildpackless-base" || builder.BuilderName == "paketobuildpacks/ubi-9-builder-buildpackless" {
-		settings.Extensions.UbiNodejsExtension.Online, err = buildpackStore.Get.
-			Execute(settings.Config.UbiNodejsExtension)
-		Expect(err).ToNot(HaveOccurred())
+	if strings.Contains(builder.BuilderName, "paketobuildpacks/builder-ubi8-buildpackless-base") || strings.Contains(builder.BuilderName, "paketobuildpacks/ubi-9-builder-buildpackless") {
+		settings.Extensions.UbiNodejsExtension.Online = settings.Config.UbiNodejsExtension
 	}
 
 	nodeBuildpack, err = filepath.Abs("../build/buildpackage.cnb")

--- a/package.toml
+++ b/package.toml
@@ -3,40 +3,48 @@
   uri = "build/buildpack.tgz"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/node-engine@7.6.2"
+  uri = "docker://docker.io/paketobuildpacks/node-engine:7.6.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/node-start@2.5.2"
+  uri = "docker://docker.io/paketobuildpacks/node-start:2.5.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/npm-install@2.1.0"
+  uri = "docker://docker.io/paketobuildpacks/npm-install:2.1.0"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/npm-start@2.3.2"
+  uri = "docker://docker.io/paketobuildpacks/npm-start:2.3.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/yarn-install@2.6.2"
+  uri = "docker://docker.io/paketobuildpacks/yarn-install:2.6.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/yarn@2.2.2"
+  uri = "docker://docker.io/paketobuildpacks/yarn:2.2.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/yarn-start@2.4.2"
+  uri = "docker://docker.io/paketobuildpacks/yarn-start:2.4.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/procfile@5.11.3"
+  uri = "docker://docker.io/paketobuildpacks/procfile:5.11.3"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/environment-variables@4.9.3"
+  uri = "docker://docker.io/paketobuildpacks/environment-variables:4.9.3"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/image-labels@4.10.2"
+  uri = "docker://docker.io/paketobuildpacks/image-labels:4.10.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/ca-certificates@3.10.4"
+  uri = "docker://docker.io/paketobuildpacks/ca-certificates:3.10.4"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/node-run-script@2.3.2"
+  uri = "docker://docker.io/paketobuildpacks/node-run-script:2.3.2"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/watchexec@3.5.4"
+  uri = "docker://docker.io/paketobuildpacks/watchexec:3.5.4"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change:
* Updates package.toml to support multi-arch
* It also changes bulidpack URIs from cnb registry to image registry URIs
* Stops using occam buildpackStore for ubi-nodejs extension in integration test
    * It is an online test and there should be no reason we can't just the image directly for the tests

## Use Cases
multi-arch

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
