### PR TITLE
Adding cpython as optional on the dependencies for building native modules

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,6 +25,11 @@ api = "0.7"
     version = "3.5.4"
 
   [[order.group]]
+    id = "paketo-buildpacks/cpython"
+    optional = true
+    version = "1.17.7"
+
+  [[order.group]]
     id = "paketo-buildpacks/node-engine"
     version = "7.7.1"
 
@@ -77,6 +82,11 @@ api = "0.7"
     id = "paketo-buildpacks/watchexec"
     optional = true
     version = "3.5.4"
+
+  [[order.group]]
+    id = "paketo-buildpacks/cpython"
+    optional = true
+    version = "1.17.7"
 
   [[order.group]]
     id = "paketo-buildpacks/node-engine"

--- a/package.toml
+++ b/package.toml
@@ -3,6 +3,9 @@
   uri = "build/buildpack.tgz"
 
 [[dependencies]]
+  uri = "docker://docker.io/paketobuildpacks/cpython:1.17.7"
+
+[[dependencies]]
   uri = "docker://docker.io/paketobuildpacks/node-engine:7.7.1"
 
 [[dependencies]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds cpython on the buildpack.toml, as it is required by node-engine during the build time in case on npm-install native modules are present.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
